### PR TITLE
fix: add long password ipmi error

### DIFF
--- a/pyipmi/errors.py
+++ b/pyipmi/errors.py
@@ -90,3 +90,11 @@ class IpmiConnectionError(Exception):
 
     def __str__(self):
         return "{}".format(self.msg)
+
+class IpmiLongPasswordError(Exception):
+    """Password longer than 20 bytes."""
+    def __init__(self, msg=None):
+        self.msg = msg
+
+    def __str__(self):
+        return "{}".format(self.msg)


### PR DESCRIPTION
The given IPMI password can be longer than IPMI expect. In that case the _parse_output method in Ipmitool's will output the following error "invalid literal for int() with base 16: 'lanplus:'". While if we look at the line that was taken from IPMI we will see that its "lanplus: password is longer than 20 bytes.". So the issue is that there is no check for this error and the function skips it and tries to convert that string from a hex into an integer. I have added an execption, regex check and the match check.