### PR TITLE
fix: escape dollar sign from args

### DIFF
--- a/pyipmi/session.py
+++ b/pyipmi/session.py
@@ -107,11 +107,18 @@ class Session(object):
 
     @property
     def auth_username(self):
-        return self._auth_username
+        return self._escape_dollar_sign(self._auth_username)
 
     @property
     def auth_password(self):
-        return self._auth_password
+        return self._escape_dollar_sign(self._auth_password)
+
+    def _escape_dollar_sign(self, password):
+        """Escape string with dollar sign in ipmitool."""
+        # The IPMI command is built and executed in a shell using Popen.
+        # The '$_' combination has its own behavior in shell and it gets
+        # replaced in the string.
+        return password.replace('$', '\$')
 
     def establish(self):
         if hasattr(self.interface, 'establish_session'):


### PR DESCRIPTION
IPMI commands get executed in a separate shell where the combination "status" has its own behavior. In our case, Popen starts a new shell, for example by running /bin/bash, and when the BMC password contains the combination above it gets replaced to "bin/bash" (in this case the combination holds the last executed command as a string). I have added a method to Session class that will escape the dollar sign. Such behavior is expected with other signs (like combination "^_") but I didn't find it critical.